### PR TITLE
fix: OPERATOR_LITERAL Wdeprecated-literal-operator

### DIFF
--- a/include/date/date.h
+++ b/include/date/date.h
@@ -84,7 +84,7 @@
 #   pragma warning(disable : 4127)
 #endif
 
-#if (defined(__GNUC__) && __GNUC__ < 5)
+#if (defined(__GNUC__) && __GNUC__ < 5) && !defined(__clang__) && !defined(_MSC_VER)
 #  define OPERATOR_LITERAL(suffix) operator"" _##suffix
 #else
 #  define OPERATOR_LITERAL(suffix) operator""_##suffix


### PR DESCRIPTION
Still warn on clang after https://github.com/HowardHinnant/date/pull/884

`warning: identifier '_y' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]`
`note: expanded from macro 'OPERATOR_LITERAL'
   88 | #  define OPERATOR_LITERAL(suffix) operator"" _##suffix`
   
This MR fix it